### PR TITLE
Update version

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -12,7 +12,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2018-09-17</releaseDate>
-  <version>0.3</version>
+  <version>0.4</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>4.2</ver>


### PR DESCRIPTION
Fixes error: "civi_flexmailer_required_tokens" service or alias has been removed or inlined when the container was compiled. You should either make it public, or stop using the container directly and use dependency injection instead

Update: Change version
